### PR TITLE
Correct the fallback message for formats supported by conversion

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DateUtils.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/DateUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2022, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,15 +217,17 @@ object DateUtils {
   def tagAndGetCudfFormat(
       meta: RapidsMeta[_, _, _],
       sparkFormat: String,
-      parseString: Boolean): String = {
+      parseString: Boolean,
+      inputFormat: String = null): String = {
+    val formatToConvert = if (inputFormat != null) inputFormat else sparkFormat
     var strfFormat: String = null
     if (GpuOverrides.getTimeParserPolicy == LegacyTimeParserPolicy) {
       try {
         // try and convert the format to cuDF format - this will throw an exception if
         // the format contains unsupported characters or words
-        strfFormat = toStrf(sparkFormat, parseString)
+        strfFormat = toStrf(formatToConvert, parseString)
         // format parsed ok but we have no 100% compatible formats in LEGACY mode
-        if (GpuToTimestamp.LEGACY_COMPATIBLE_FORMATS.contains(sparkFormat)) {
+        if (GpuToTimestamp.LEGACY_COMPATIBLE_FORMATS.contains(formatToConvert)) {
           // LEGACY support has a number of issues that mean we cannot guarantee
           // compatibility with CPU
           // - we can only support 4 digit years but Spark supports a wider range
@@ -249,9 +251,9 @@ object DateUtils {
       try {
         // try and convert the format to cuDF format - this will throw an exception if
         // the format contains unsupported characters or words
-        strfFormat = toStrf(sparkFormat, parseString)
+        strfFormat = toStrf(formatToConvert, parseString)
         // format parsed ok, so it is either compatible (tested/certified) or incompatible
-        if (!GpuToTimestamp.CORRECTED_COMPATIBLE_FORMATS.contains(sparkFormat) &&
+        if (!GpuToTimestamp.CORRECTED_COMPATIBLE_FORMATS.contains(formatToConvert) &&
           !meta.conf.incompatDateFormats) {
           meta.willNotWorkOnGpu(s"CORRECTED format '$sparkFormat' on the GPU is not guaranteed " +
             s"to produce the same results as Spark on CPU. Set " +

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/datetimeExpressions.scala
@@ -1033,7 +1033,7 @@ class FromUnitTimeMeta(a: FromUnixTime,
             tempFormat
           }.getOrElse(sparkFormat)
         strfFormat = DateUtils.tagAndGetCudfFormat(this,
-          inputFormat, a.left.dataType == DataTypes.StringType)
+          sparkFormat, a.left.dataType == DataTypes.StringType, inputFormat)
       case None =>
         willNotWorkOnGpu("format has to be a string literal")
     }


### PR DESCRIPTION
```
scala> Seq(System.currentTimeMillis()/1000).toDF("dt").repartition(1).selectExpr("*", "from_unixtime(dt, 'yyyyMMdd')").show
23/12/06 10:01:23 WARN GpuOverrides: 
!Exec <ProjectExec> cannot run on GPU because not all expressions can be replaced
  @Expression <Alias> cast(dt#22L as string) AS dt#29 could run on GPU
    @Expression <Cast> cast(dt#22L as string) could run on GPU
      @Expression <AttributeReference> dt#22L could run on GPU
  @Expression <Alias> from_unixtime(dt#22L, yyyyMMdd, Some(UTC)) AS from_unixtime(dt, yyyyMMdd)#30 could run on GPU
    !Expression <FromUnixTime> from_unixtime(dt#22L, yyyyMMdd, Some(UTC)) cannot run on GPU because LEGACY format 'yyyyMMdd' on the GPU is not guaranteed to produce the same results as Spark on CPU. Set spark.rapids.sql.incompatibleDateFormats.enabled=true to force onto GPU.
      @Expression <AttributeReference> dt#22L could run on GPU
      @Expression <Literal> yyyyMMdd could run on GPU
  !Exec <ShuffleExchangeExec> cannot run on GPU because Columnar exchange without columnar children is inefficient
    @Partitioning <SinglePartition$> could run on GPU
    ! <LocalTableScanExec> cannot run on GPU because GPU does not currently support the operator class org.apache.spark.sql.execution.LocalTableScanExec
      @Expression <AttributeReference> dt#22L could run on GPU

+----------+---------------------------+
|        dt|from_unixtime(dt, yyyyMMdd)|
+----------+---------------------------+
|1701856883|                   20231206|
+----------+---------------------------+


scala> spark.conf.set("spark.rapids.sql.incompatibleDateFormats.enabled", "true")

scala> Seq(System.currentTimeMillis()/1000).toDF("dt").repartition(1).selectExpr("*", "from_unixtime(dt, 'yyyyMMdd')").show
23/12/06 10:03:00 WARN GpuOverrides: 
*Exec <ProjectExec> will run on GPU
  *Expression <Alias> cast(dt#40L as string) AS dt#47 will run on GPU
    *Expression <Cast> cast(dt#40L as string) will run on GPU
  *Expression <Alias> from_unixtime(dt#40L, yyyyMMdd, Some(UTC)) AS from_unixtime(dt, yyyyMMdd)#48 will run on GPU
    *Expression <FromUnixTime> from_unixtime(dt#40L, yyyyMMdd, Some(UTC)) will run on GPU
  *Exec <ShuffleExchangeExec> will run on GPU
    *Partitioning <SinglePartition$> will run on GPU
    ! <LocalTableScanExec> cannot run on GPU because GPU does not currently support the operator class org.apache.spark.sql.execution.LocalTableScanExec
      @Expression <AttributeReference> dt#40L could run on GPU

+----------+---------------------------+
|        dt|from_unixtime(dt, yyyyMMdd)|
+----------+---------------------------+
|1701856980|                   20231206|
+----------+---------------------------+
```
