### PR TITLE
capture nsys report

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -522,7 +522,6 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
     val nsysStopCommand = "nsys stop"
     val result: String = nsysStopCommand.!!
     println(s"Nsys Stop Command output: $result")
-    Thread.sleep(120* 1000)
     // here the report is generated. customer need to write another command to do HDFS upload
     // val hdfsUploadCommand = "..."
     // ...

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/Plugin.scala
@@ -408,6 +408,11 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
       extraExecutorPlugins.foreach(_.init(pluginContext, extraConf))
       GpuSemaphore.initialize()
       FileCache.init(pluginContext)
+      // here customer need to make sure the path exists and is writable
+      val nsysStartComamnd = "nsys start -o /opt/spark/work-dir/test_%h_%p" +
+        ".nsys-rep"
+      val result: String = nsysStartComamnd.!!
+      println(s"Nsys Start Command output: $result")
     } catch {
       // Exceptions in executor plugin can cause a single thread to die but the executor process
       // sticks around without any useful info until it hearbeat times out. Print what happened
@@ -513,6 +518,14 @@ class RapidsExecutorPlugin extends ExecutorPlugin with Logging {
     extraExecutorPlugins.foreach(_.shutdown())
     FileCache.shutdown()
     GpuCoreDumpHandler.shutdown()
+
+    val nsysStopCommand = "nsys stop"
+    val result: String = nsysStopCommand.!!
+    println(s"Nsys Stop Command output: $result")
+    Thread.sleep(120* 1000)
+    // here the report is generated. customer need to write another command to do HDFS upload
+    // val hdfsUploadCommand = "..."
+    // ...
   }
 
   override def onTaskFailed(failureReason: TaskFailedReason): Unit = {


### PR DESCRIPTION
This is for customer to try capture nsys report. The report is generated before executor exits, so user should be able to upload the report to their persist storage

This requires the change at entry point as well:

```
...
case "$1" in
  driver)
    shift 1
    CMD=(
      "$SPARK_HOME/bin/spark-submit"
      --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
      --deploy-mode client
      "$@"
    )
    ;;
  executor)
    shift 1
    CMD=(
      nsys launch --cuda-memory-usage=true
      ${JAVA_HOME}/bin/java
      "${SPARK_EXECUTOR_JAVA_OPTS[@]}"
      -Xms$SPARK_EXECUTOR_MEMORY
      -Xmx$SPARK_EXECUTOR_MEMORY
      -cp "$SPARK_CLASSPATH:$SPARK_DIST_CLASSPATH"
      org.apache.spark.scheduler.cluster.k8s.KubernetesExecutorBackend
      --driver-url $SPARK_DRIVER_URL
      --executor-id $SPARK_EXECUTOR_ID
      --cores $SPARK_EXECUTOR_CORES
      --app-id $SPARK_APPLICATION_ID
      --hostname $SPARK_EXECUTOR_POD_IP
      --resourceProfileId $SPARK_RESOURCE_PROFILE_ID
      --podName $SPARK_EXECUTOR_POD_NAME
    )
    ;;
...
```

NOTE `--cuda-memory-usage=true` will cause GPU perf drop, so if you don't need memory usage analysis, you can remove it from the nsys comamnd.