### PR TITLE
Polish log

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4530,8 +4530,8 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
       case sp: SparkPlan => (sp.canonicalized, true, 0)
       case product => (product, false, level)
     }
-    sb.append("\n").append(" " * 4 * numIndent)
-      .append(canonPro.productPrefix).append(" hash: ").append(canonPro.##)
+    sb.append("\n").append(" " * 4 * numIndent).append(canonPro.getClass.getSimpleName)
+      .append("-").append(canonPro.productPrefix).append(" hash: ").append(canonPro.##)
     (0 until canonPro.productArity).foreach { idx =>
       canonPro.productElement(idx) match {
         case _: SparkPlan =>
@@ -4541,8 +4541,10 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         case p: SProduct if pLevel < MaxLevel =>
           p2s(p, sb, numIndent + 1, pLevel + 1)
         case o =>
-          sb.append("\n").append(" " * 4 * (numIndent + 1))
-            .append(o.getClass.getSimpleName).append(" hash: ").append(o.##)
+          if (pLevel < MaxLevel) {
+            sb.append("\n").append(" " * 4 * (numIndent + 1))
+              .append(o.getClass.getSimpleName).append(" hash: ").append(o.##)
+          }
       }
     }
     if(isPlan) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4542,7 +4542,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
 
   private def e2s(ex: Exchange, moreDetails: Boolean = false): String = {
     val sb = new StringBuilder(
-      s"exchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##}), ")
+      s"exchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##})")
     if (moreDetails) {
       sb.append("\nWhole tree info:")
       p2s(ex, sb)
@@ -4560,7 +4560,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         if (exchange.child.find(f => f.isInstanceOf[GpuFileSourceScanExec]).isDefined) {
           val cachedExchange =
             exchanges.getOrElseUpdate(exchange.canonicalized.asInstanceOf[Exchange], exchange)
-          if (cachedExchange.ne(exchange)) {
+          if (cachedExchange.eq(exchange)) {
             logWarning(s"==>REUSED_EX_DEBUG: found an ${e2s(exchange)} can reuse the " +
               s"cached one ${e2s(cachedExchange)}")
           } else {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -18,6 +18,7 @@ package com.nvidia.spark.rapids
 
 import java.time.ZoneId
 
+import scala.{Product => SProduct}
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
@@ -4523,11 +4524,10 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
 
   private val exchanges = TrieMap.empty[Exchange, Exchange]
 
-  private def p2s(pro: Any, sb: StringBuilder, level: Int = 1): Unit = {
+  private def p2s(pro: SProduct, sb: StringBuilder, level: Int = 1): Unit = {
     val (canonPro, isPlan) = pro match {
       case sp: SparkPlan => (sp.canonicalized, true)
-      case product: Product => (product, false)
-      case t => throw new RuntimeException(s"Unsupported type ${t.getClass.getSimpleName}")
+      case product => (product, false)
     }
     sb.append("\n").append(" " * 4 * level)
       .append(canonPro.productPrefix).append(" hash: ").append(canonPro.##)
@@ -4537,7 +4537,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
           // ignore
         case Seq(_: SparkPlan, _: SparkPlan, _@_*) =>
           // ignore
-        case p: Product =>
+        case p: SProduct =>
           p2s(p, sb, level + 1)
         case o =>
           sb.append("\n").append(" " * 4 * (level + 1))
@@ -4554,7 +4554,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
       s"exchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##})")
     if (moreDetails) {
       sb.append("\nWhole tree info:")
-      p2s(ex.asInstanceOf[Product], sb)
+      p2s(ex, sb)
     }
     sb.toString()
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4523,31 +4523,29 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
 
   private val exchanges = TrieMap.empty[Exchange, Exchange]
 
-  private def c2s(inputPlan: SparkPlan, sb: StringBuilder, level: Int = 1): Unit = {
-    inputPlan.children.foreach { sp =>
-      sb.append("\n").append(" " * 4 * level)
-        .append(sp.productPrefix).append(" canonicalized hash: ").append(sp.canonicalized.##)
-      (0 until sp.productArity).foreach { idx =>
-        sp.productElement(idx) match {
-          case _: SparkPlan =>
-            // ignore
-          case Seq(_: SparkPlan, _: SparkPlan, _@_*) =>
-            // ignore
-          case o =>
-            sb.append("\n").append(" " * 4 * (level + 1))
-              .append(o.getClass.getSimpleName).append(" hash: ").append(o.##)
-        }
+  private def p2s(plan: SparkPlan, sb: StringBuilder, level: Int = 1): Unit = {
+    sb.append("\n").append(" " * 4 * level)
+      .append(plan.productPrefix).append(" canonicalized hash: ").append(plan.canonicalized.##)
+    (0 until plan.productArity).foreach { idx =>
+      plan.productElement(idx) match {
+        case _: SparkPlan =>
+        // ignore
+        case Seq(_: SparkPlan, _: SparkPlan, _@_*) =>
+        // ignore
+        case o =>
+          sb.append("\n").append(" " * 4 * (level + 1))
+            .append(o.getClass.getSimpleName).append(" hash: ").append(o.##)
       }
-      sp.children.foreach(c2s(_, sb, level + 1))
     }
+    plan.children.foreach(p2s(_, sb, level + 1))
   }
 
-  private def e2s(ex: Exchange, logChildren: Boolean = false): String = {
+  private def e2s(ex: Exchange, moreDetails: Boolean = false): String = {
     val sb = new StringBuilder(
       s"exchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##}), ")
-    if (logChildren) {
-      sb.append("children:")
-      c2s(ex.child, sb)
+    if (moreDetails) {
+      sb.append("\nWhole tree info:")
+      p2s(ex, sb)
     }
     sb.toString()
   }
@@ -4556,24 +4554,24 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
     logWarning(s"==>REUSED_EX_DEBUG: reuse exchange enabled ?= ${conf.exchangeReuseEnabled}")
     sparkPlan.foreach {
       case exchange: Exchange =>
-        val cachedExchange =
-          exchanges.getOrElseUpdate(exchange.canonicalized.asInstanceOf[Exchange], exchange)
-        if (cachedExchange.ne(exchange)) {
-          logWarning(s"==>REUSED_EX_DEBUG: found an ${e2s(exchange)} can reuse the " +
-            s"cached one ${e2s(cachedExchange)}")
-        } else {
-          if (exchanges.size > 1) {
-            // For this case, we only care about the 4 ones closest to the file scan.
-            if (exchange.child.find(f=>f.isInstanceOf[GpuFileSourceScanExec]).isDefined) {
+        // For this case, we only care about the 4 ones closest to the file scan.
+        if (exchange.child.find(f => f.isInstanceOf[GpuFileSourceScanExec]).isDefined) {
+          val cachedExchange =
+            exchanges.getOrElseUpdate(exchange.canonicalized.asInstanceOf[Exchange], exchange)
+          if (cachedExchange.ne(exchange)) {
+            logWarning(s"==>REUSED_EX_DEBUG: found an ${e2s(exchange)} can reuse the " +
+              s"cached one ${e2s(cachedExchange)}")
+          } else {
+            if (exchanges.size > 1) {
               logWarning(s"==>REUSED_EX_DEBUG: found a different ${e2s(exchange, true)}")
               logWarning(s"==>REUSED_EX_DEBUG: current Map: \n" +
-                s"    ${exchanges.map{case (k, v) => (k.##, e2s(v))}.mkString("\n")}")
+                s"    ${exchanges.map { case (k, v) => (k.##, e2s(v)) }.mkString("\n    ")}")
             } else {
-              logWarning(s"==>REUSED_EX_DEBUG: ignore this ${e2s(exchange)}, not a leaf one")
+              logWarning(s"==>REUSED_EX_DEBUG: skip the first ${e2s(exchange)}")
             }
-          } else {
-            logWarning(s"==>REUSED_EX_DEBUG: skip the first ${e2s(exchange)}")
           }
+        } else {
+          logWarning(s"==>REUSED_EX_DEBUG: ignore this ${e2s(exchange)}, not a leaf one")
         }
       case re: ReusedExchangeExec =>
         logWarning(s"==>REUSED_EX_DEBUG: catch a ReusedExchangeExec," +

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4560,24 +4560,15 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
         if (exchange.child.find(f => f.isInstanceOf[GpuFileSourceScanExec]).isDefined) {
           val cachedExchange =
             exchanges.getOrElseUpdate(exchange.canonicalized.asInstanceOf[Exchange], exchange)
-          if (cachedExchange.eq(exchange)) {
-            logWarning(s"==>REUSED_EX_DEBUG: found an ${e2s(exchange)} can reuse the " +
-              s"cached one ${e2s(cachedExchange)}")
+          if (cachedExchange.ne(exchange)) {
+            logWarning(s"==>REUSED_EX_DEBUG: the cached ${e2s(cachedExchange)} can be " +
+              s"reused by ${e2s(exchange, true)}")
           } else {
-            if (exchanges.size > 1) {
-              logWarning(s"==>REUSED_EX_DEBUG: found a different ${e2s(exchange, true)}")
-           //   logWarning(s"==>REUSED_EX_DEBUG: current Map: \n" +
-           //     s"    ${exchanges.map { case (k, v) => (k.##, e2s(v)) }.mkString("\n    ")}")
-            } else {
-              logWarning(s"==>REUSED_EX_DEBUG: skip the first ${e2s(exchange)}")
-            }
+            logWarning(s"==>REUSED_EX_DEBUG: found a different ${e2s(exchange, true)}")
           }
         } else {
           logWarning(s"==>REUSED_EX_DEBUG: ignore this ${e2s(exchange)}, not a leaf one")
         }
-      case re: ReusedExchangeExec =>
-        logWarning(s"==>REUSED_EX_DEBUG: catch a ReusedExchangeExec," +
-          s"canonicalized hash: ${re.canonicalized.##}")
       case _ => // ignore
     }
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4555,7 +4555,8 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
     sparkPlan.foreach {
       case exchange: Exchange =>
         // For this case, we only care about the 4 ones closest to the file scan.
-        if (exchange.child.find(f => f.isInstanceOf[GpuFileSourceScanExec]).isDefined) {
+        if (exchange.child.find(f => f.isInstanceOf[GpuFileSourceScanExec]).isDefined &&
+            exchange.child.find(f=>f.isInstanceOf[Exchange]).isEmpty) {
           val cachedExchange =
             exchanges.getOrElseUpdate(exchange.canonicalized.asInstanceOf[Exchange], exchange)
           if (cachedExchange.ne(exchange)) {
@@ -4595,7 +4596,9 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
             s"\nOriginal Plan:\n$plan\nTransformed Plan:\n$updatedPlan")
         }
         logWarning(s"\n\n==>REUSED_EX_DEBUG: Start to look at reused exchange under $context")
-        lookAtReusedExchange(updatedPlan)
+        if (context.isEmpty) {
+          lookAtReusedExchange(updatedPlan)
+        }
         updatedPlan
       }
     } else if (conf.isSqlEnabled && conf.isSqlExplainOnlyEnabled) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4523,8 +4523,10 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
   override def apply(sparkPlan: SparkPlan): SparkPlan = applyWithContext(sparkPlan, None)
 
   private val exchanges = TrieMap.empty[Exchange, Exchange]
+  private val maxLevel = 4
 
   private def p2s(pro: SProduct, sb: StringBuilder, level: Int = 1): Unit = {
+    if (level > maxLevel) return
     val (canonPro, isPlan) = pro match {
       case sp: SparkPlan => (sp.canonicalized, true)
       case product => (product, false)

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4552,7 +4552,8 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
 
   private def lookAtReusedExchange(sparkPlan: SparkPlan): Unit = {
     logWarning(s"==>REUSED_EX_DEBUG: reuse exchange enabled ?= ${conf.exchangeReuseEnabled} " +
-      s"with input plan $sparkPlan")
+      s"with input plan ${sparkPlan.nodeName}, current Map: \n" +
+      s"    ${exchanges.map { case (k, v) => (k.##, e2s(v)) }.mkString("\n    ")}")
     sparkPlan.foreach {
       case exchange: Exchange =>
         // For this case, we only care about the 4 ones closest to the file scan.
@@ -4565,8 +4566,8 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
           } else {
             if (exchanges.size > 1) {
               logWarning(s"==>REUSED_EX_DEBUG: found a different ${e2s(exchange, true)}")
-              logWarning(s"==>REUSED_EX_DEBUG: current Map: \n" +
-                s"    ${exchanges.map { case (k, v) => (k.##, e2s(v)) }.mkString("\n    ")}")
+           //   logWarning(s"==>REUSED_EX_DEBUG: current Map: \n" +
+           //     s"    ${exchanges.map { case (k, v) => (k.##, e2s(v)) }.mkString("\n    ")}")
             } else {
               logWarning(s"==>REUSED_EX_DEBUG: skip the first ${e2s(exchange)}")
             }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4523,21 +4523,23 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
   override def apply(sparkPlan: SparkPlan): SparkPlan = applyWithContext(sparkPlan, None)
 
   private val exchanges = TrieMap.empty[Exchange, Exchange]
-  private val MaxLevel = 1
+  private val MaxLevel = 2
 
   private def p2s(pro: SProduct, sb: StringBuilder, numIndent: Int = 1, level: Int = 0): Unit = {
     val (canonPro, isPlan, pLevel) = pro match {
       case sp: SparkPlan => (sp.canonicalized, true, 0)
       case product => (product, false, level)
     }
-    sb.append("\n").append(" " * 4 * numIndent).append(canonPro.getClass.getSimpleName)
-      .append("-").append(canonPro.productPrefix).append(" hash: ").append(canonPro.##)
+    sb.append("\n").append(" " * 4 * numIndent)
+      .append(canonPro.productPrefix).append(" hash: ").append(canonPro.##)
     (0 until canonPro.productArity).foreach { idx =>
       canonPro.productElement(idx) match {
         case _: SparkPlan =>
           // ignore
         case Seq(_: SparkPlan, _: SparkPlan, _@_*) =>
           // ignore
+        case st: StructType =>
+          p2s(st, sb, numIndent + 1, MaxLevel)
         case p: SProduct if pLevel < MaxLevel =>
           p2s(p, sb, numIndent + 1, pLevel + 1)
         case o =>

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4544,11 +4544,11 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
 
   private def e2s(ex: Exchange, logChildren: Boolean = false): String = {
     val sb = new StringBuilder(
-      s"exchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##})")
+      s"\nexchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##})")
     if (logChildren) {
       c2s(ex.child, sb)
     }
-    sb.append("\n\n").toString()
+    sb.append("\n").toString()
   }
 
   private def lookAtReusedExchange(sparkPlan: SparkPlan): Unit = {
@@ -4595,7 +4595,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
           logWarning(s"${logPrefix}Transformed query:" +
             s"\nOriginal Plan:\n$plan\nTransformed Plan:\n$updatedPlan")
         }
-        logWarning("==>REUSED_EX_DEBUG: Start to look at reused exchange...")
+        logWarning("\n\n==>REUSED_EX_DEBUG: Start to look at reused exchange...")
         lookAtReusedExchange(updatedPlan)
         updatedPlan
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4551,12 +4551,12 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
   }
 
   private def lookAtReusedExchange(sparkPlan: SparkPlan): Unit = {
-    logWarning(s"==>REUSED_EX_DEBUG: reuse exchange enabled ?= ${conf.exchangeReuseEnabled}")
+    logWarning(s"==>REUSED_EX_DEBUG: reuse exchange enabled ?= ${conf.exchangeReuseEnabled} " +
+      s"with input plan $sparkPlan")
     sparkPlan.foreach {
       case exchange: Exchange =>
         // For this case, we only care about the 4 ones closest to the file scan.
-        if (exchange.child.find(f => f.isInstanceOf[GpuFileSourceScanExec]).isDefined &&
-            exchange.child.find(f=>f.isInstanceOf[Exchange]).isEmpty) {
+        if (exchange.child.find(f => f.isInstanceOf[GpuFileSourceScanExec]).isDefined) {
           val cachedExchange =
             exchanges.getOrElseUpdate(exchange.canonicalized.asInstanceOf[Exchange], exchange)
           if (cachedExchange.ne(exchange)) {

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4587,7 +4587,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
           logWarning(s"${logPrefix}Transformed query:" +
             s"\nOriginal Plan:\n$plan\nTransformed Plan:\n$updatedPlan")
         }
-        logWarning(s"\n\n==>REUSED_EX_DEBUG: Start to look at reused exchange under $context")
+        logWarning(s"==>REUSED_EX_DEBUG: Start to look at reused exchange under $context")
         if (context.isEmpty) {
           lookAtReusedExchange(updatedPlan)
         }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4526,7 +4526,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
   private def c2s(inputPlan: SparkPlan, sb: StringBuilder, level: Int = 1): Unit = {
     inputPlan.children.foreach { sp =>
       sb.append("\n").append(" " * 4 * level)
-        .append(sp.productPrefix).append("canonicalized hash: ").append(sp.canonicalized.##)
+        .append(sp.productPrefix).append(" canonicalized hash: ").append(sp.canonicalized.##)
       (0 until sp.productArity).foreach { idx =>
         sp.productElement(idx) match {
           case _: SparkPlan =>
@@ -4548,7 +4548,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
     if (logChildren) {
       c2s(ex.child, sb)
     }
-    sb.toString()
+    sb.append("\n\n").toString()
   }
 
   private def lookAtReusedExchange(sparkPlan: SparkPlan): Unit = {
@@ -4565,8 +4565,8 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
             // For this case, we only care about the 4 ones closest to the file scan.
             if (exchange.child.find(f=>f.isInstanceOf[GpuFileSourceScanExec]).isDefined) {
               logWarning(s"==>REUSED_EX_DEBUG: found a different ${e2s(exchange, true)}")
-              logWarning(s"==>REUSED_EX_DEBUG: current Map \n" +
-                s"    ${exchanges.map{case (k, v) => (e2s(k), e2s(v))}}")
+              logWarning(s"==>REUSED_EX_DEBUG: current Map: \n" +
+                s"    ${exchanges.map{case (k, v) => (e2s(k), e2s(v))}.mkString("\n    ")}")
             } else {
               logWarning(s"==>REUSED_EX_DEBUG: ignore this ${e2s(exchange)}, not a leaf one")
             }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4523,15 +4523,14 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
   override def apply(sparkPlan: SparkPlan): SparkPlan = applyWithContext(sparkPlan, None)
 
   private val exchanges = TrieMap.empty[Exchange, Exchange]
-  private val maxLevel = 4
+  private val MaxLevel = 1
 
-  private def p2s(pro: SProduct, sb: StringBuilder, level: Int = 1): Unit = {
-    if (level > maxLevel) return
-    val (canonPro, isPlan) = pro match {
-      case sp: SparkPlan => (sp.canonicalized, true)
-      case product => (product, false)
+  private def p2s(pro: SProduct, sb: StringBuilder, numIndent: Int = 1, level: Int = 0): Unit = {
+    val (canonPro, isPlan, pLevel) = pro match {
+      case sp: SparkPlan => (sp.canonicalized, true, 0)
+      case product => (product, false, level)
     }
-    sb.append("\n").append(" " * 4 * level)
+    sb.append("\n").append(" " * 4 * numIndent)
       .append(canonPro.productPrefix).append(" hash: ").append(canonPro.##)
     (0 until canonPro.productArity).foreach { idx =>
       canonPro.productElement(idx) match {
@@ -4539,15 +4538,15 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
           // ignore
         case Seq(_: SparkPlan, _: SparkPlan, _@_*) =>
           // ignore
-        case p: SProduct =>
-          p2s(p, sb, level + 1)
+        case p: SProduct if pLevel < MaxLevel =>
+          p2s(p, sb, numIndent + 1, pLevel + 1)
         case o =>
-          sb.append("\n").append(" " * 4 * (level + 1))
+          sb.append("\n").append(" " * 4 * (numIndent + 1))
             .append(o.getClass.getSimpleName).append(" hash: ").append(o.##)
       }
     }
     if(isPlan) {
-      canonPro.asInstanceOf[SparkPlan].children.foreach(p2s(_, sb, level + 1))
+      canonPro.asInstanceOf[SparkPlan].children.foreach(p2s(_, sb, numIndent + 1))
     }
   }
 

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -18,7 +18,7 @@ package com.nvidia.spark.rapids
 
 import java.time.ZoneId
 
-import scala.collection.mutable
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable.ListBuffer
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
@@ -4521,46 +4521,62 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
   // gets called once for each query stage (where a query stage is an `Exchange`).
   override def apply(sparkPlan: SparkPlan): SparkPlan = applyWithContext(sparkPlan, None)
 
+  private val exchanges = TrieMap.empty[Exchange, Exchange]
+
+  private def c2s(inputPlan: SparkPlan, sb: StringBuilder, level: Int = 1): Unit = {
+    inputPlan.children.foreach { sp =>
+      sb.append("\n").append(" " * 4 * level)
+        .append(sp.productPrefix).append("canonicalized hash: ").append(sp.canonicalized.##)
+      (0 until sp.productArity).foreach { idx =>
+        sp.productElement(idx) match {
+          case _: SparkPlan =>
+            // ignore
+          case Seq(_: SparkPlan, _: SparkPlan, _@_*) =>
+            // ignore
+          case o =>
+            sb.append("\n").append(" " * 4 * (level + 1))
+              .append(o.getClass.getSimpleName).append(" hash: ").append(o.##)
+        }
+      }
+      sp.children.foreach(c2s(_, sb, level + 1))
+    }
+  }
+
+  private def e2s(ex: Exchange, logChildren: Boolean = false): String = {
+    val sb = new StringBuilder(
+      s"exchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##})")
+    if (logChildren) {
+      c2s(ex.child, sb)
+    }
+    sb.toString()
+  }
+
   private def lookAtReusedExchange(sparkPlan: SparkPlan): Unit = {
-    val exchanges = mutable.Map.empty[SparkPlan, Exchange]
-    logInfo(s"==>REUSED_EX_DEBUG: reuse exchange enabled ?= ${conf.exchangeReuseEnabled}")
+    logWarning(s"==>REUSED_EX_DEBUG: reuse exchange enabled ?= ${conf.exchangeReuseEnabled}")
     sparkPlan.foreach {
       case exchange: Exchange =>
-        val cachedExchange = exchanges.getOrElseUpdate(exchange.canonicalized, exchange)
+        val cachedExchange =
+          exchanges.getOrElseUpdate(exchange.canonicalized.asInstanceOf[Exchange], exchange)
         if (cachedExchange.ne(exchange)) {
-          logInfo(
-            s"""==>REUSED_EX_DEBUG: found an exchange:
-               |     $exchange
-               |     (Canonicalized: ${exchange.canonicalized})
-               |   can reuse the cached one:
-               |     $cachedExchange
-               |     (Canonicalized: ${cachedExchange.canonicalized})
-            """.stripMargin)
+          logWarning(s"==>REUSED_EX_DEBUG: found an ${e2s(exchange)} can reuse the " +
+            s"cached one ${e2s(cachedExchange)}")
         } else {
           if (exchanges.size > 1) {
-            // found maybe a different exchange. For this case, we only care about the
-            // 4 leaf ones.
-            if (cachedExchange.child.find(f=>f.isInstanceOf[Exchange]).isDefined) {
-              logInfo("==>REUSED_EX_DEBUG: ignore this exchange, it is not the leaf one")
+            // For this case, we only care about the 4 ones closest to the file scan.
+            if (exchange.child.find(f=>f.isInstanceOf[GpuFileSourceScanExec]).isDefined) {
+              logWarning(s"==>REUSED_EX_DEBUG: found a different ${e2s(exchange, true)}")
+              logWarning(s"==>REUSED_EX_DEBUG: current Map \n" +
+                s"    ${exchanges.map{case (k, v) => (e2s(k), e2s(v))}}")
             } else {
-              logInfo(
-                s"""==>REUSED_EX_DEBUG: found maybe a different exchange:
-                   |   $cachedExchange
-                   |   (Canonicalized: ${cachedExchange.canonicalized})
-                """.stripMargin)
+              logWarning(s"==>REUSED_EX_DEBUG: ignore this ${e2s(exchange)}, not a leaf one")
             }
           } else {
-            // the first one
+            logWarning(s"==>REUSED_EX_DEBUG: skip the first ${e2s(exchange)}")
           }
         }
       case re: ReusedExchangeExec =>
-        logInfo(s"==>REUSED_EX_DEBUG: catch a ReusedExchangeExec, its child is: ")
-        logInfo(
-          s"""
-            |    ${re.child}
-            |  ===> child canonicalized
-            |    ${re.child.canonicalized}
-            |""".stripMargin)
+        logWarning(s"==>REUSED_EX_DEBUG: catch a ReusedExchangeExec," +
+          s"canonicalized hash: ${re.canonicalized.##}")
       case _ => // ignore
     }
   }
@@ -4579,7 +4595,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
           logWarning(s"${logPrefix}Transformed query:" +
             s"\nOriginal Plan:\n$plan\nTransformed Plan:\n$updatedPlan")
         }
-        logInfo("==>REUSED_EX_DEBUG: Start to look at reused exchange...")
+        logWarning("==>REUSED_EX_DEBUG: Start to look at reused exchange...")
         lookAtReusedExchange(updatedPlan)
         updatedPlan
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4595,7 +4595,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
           logWarning(s"${logPrefix}Transformed query:" +
             s"\nOriginal Plan:\n$plan\nTransformed Plan:\n$updatedPlan")
         }
-        logWarning("\n\n==>REUSED_EX_DEBUG: Start to look at reused exchange...")
+        logWarning(s"\n\n==>REUSED_EX_DEBUG: Start to look at reused exchange under $context")
         lookAtReusedExchange(updatedPlan)
         updatedPlan
       }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4544,11 +4544,12 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
 
   private def e2s(ex: Exchange, logChildren: Boolean = false): String = {
     val sb = new StringBuilder(
-      s"\nexchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##})")
+      s"exchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##}), ")
     if (logChildren) {
+      sb.append("children:")
       c2s(ex.child, sb)
     }
-    sb.append("\n").toString()
+    sb.toString()
   }
 
   private def lookAtReusedExchange(sparkPlan: SparkPlan): Unit = {
@@ -4566,7 +4567,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
             if (exchange.child.find(f=>f.isInstanceOf[GpuFileSourceScanExec]).isDefined) {
               logWarning(s"==>REUSED_EX_DEBUG: found a different ${e2s(exchange, true)}")
               logWarning(s"==>REUSED_EX_DEBUG: current Map: \n" +
-                s"    ${exchanges.map{case (k, v) => (e2s(k), e2s(v))}.mkString("\n    ")}")
+                s"    ${exchanges.map{case (k, v) => (k.##, e2s(v))}.mkString("\n")}")
             } else {
               logWarning(s"==>REUSED_EX_DEBUG: ignore this ${e2s(exchange)}, not a leaf one")
             }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuOverrides.scala
@@ -4523,21 +4523,30 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
 
   private val exchanges = TrieMap.empty[Exchange, Exchange]
 
-  private def p2s(plan: SparkPlan, sb: StringBuilder, level: Int = 1): Unit = {
+  private def p2s(pro: Any, sb: StringBuilder, level: Int = 1): Unit = {
+    val (canonPro, isPlan) = pro match {
+      case sp: SparkPlan => (sp.canonicalized, true)
+      case product: Product => (product, false)
+      case t => throw new RuntimeException(s"Unsupported type ${t.getClass.getSimpleName}")
+    }
     sb.append("\n").append(" " * 4 * level)
-      .append(plan.productPrefix).append(" canonicalized hash: ").append(plan.canonicalized.##)
-    (0 until plan.productArity).foreach { idx =>
-      plan.productElement(idx) match {
+      .append(canonPro.productPrefix).append(" hash: ").append(canonPro.##)
+    (0 until canonPro.productArity).foreach { idx =>
+      canonPro.productElement(idx) match {
         case _: SparkPlan =>
-        // ignore
+          // ignore
         case Seq(_: SparkPlan, _: SparkPlan, _@_*) =>
-        // ignore
+          // ignore
+        case p: Product =>
+          p2s(p, sb, level + 1)
         case o =>
           sb.append("\n").append(" " * 4 * (level + 1))
             .append(o.getClass.getSimpleName).append(" hash: ").append(o.##)
       }
     }
-    plan.children.foreach(p2s(_, sb, level + 1))
+    if(isPlan) {
+      canonPro.asInstanceOf[SparkPlan].children.foreach(p2s(_, sb, level + 1))
+    }
   }
 
   private def e2s(ex: Exchange, moreDetails: Boolean = false): String = {
@@ -4545,7 +4554,7 @@ case class GpuOverrides() extends Rule[SparkPlan] with Logging {
       s"exchange(id: ${ex.id}, canonicalized hash: ${ex.canonicalized.##})")
     if (moreDetails) {
       sb.append("\nWhole tree info:")
-      p2s(ex, sb)
+      p2s(ex.asInstanceOf[Product], sb)
     }
     sb.toString()
   }

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuTransitionOverrides.scala
@@ -694,12 +694,15 @@ class GpuTransitionOverrides extends Rule[SparkPlan] {
           }.getOrElse(g)
       }
     }
-
     // If an exchange is at the top of the plan being remapped, this is likely due to AQE
     // re-planning, and we're not allowed to change an exchange to a reused exchange in that case.
     p match {
-      case e: Exchange => e.mapChildren(doFixup)
-      case _ => doFixup(p)
+      case e: Exchange =>
+        logWarning("==>REUSED_EX_DEBUG: try fix up children of an exchange")
+        e.mapChildren(doFixup)
+      case _ =>
+        logWarning(s"==>REUSED_EX_DEBUG: try to fix up a spark plan ${p.nodeName}")
+        doFixup(p)
     }
   }
 


### PR DESCRIPTION
It focuses on the the top 4 exchange nodes.
```
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: Start to look at reused exchange under None
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: reuse exchange enabled ?= true with input plan GpuColumnarExchange, current Map: 
    
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: found a different exchange(id: 899, canonicalized hash: 1651290344)
Whole tree info:
    GpuShuffleExchangeExec hash: 1651290344
        GpuHashPartitioning hash: 506624161
            ArrayBuffer hash: 195585138
            Integer hash: 200
        ENSURE_REQUIREMENTS hash: -1256111375
        None hash: 2433880
        GpuHashAggregateExec hash: 992064433
            None hash: 2433880
            ArrayBuffer hash: -1343466678
            :: hash: 1577311079
                GpuAggregateExpression hash: -65238598
                :: hash: -895177707
            :: hash: 1871809590
                AttributeReference hash: -1481402425
                :: hash: -2133478641
            ArrayBuffer hash: 1119666541
            Long hash: 1073741824
            Boolean hash: 1231
            Double hash: -1806074301
            Boolean hash: 1237
            Boolean hash: 1237
            GpuProjectExec hash: 636852867
                :: hash: 411458217
                    AttributeReference hash: -403150997
                    :: hash: 1995159257
                GpuFilterExec hash: -451143750
                    GpuAnd hash: -1213905005
                        GpuEqualTo hash: -1874827664
                        GpuIsNotNull hash: 1232619969
                    GpuFileSourceScanExec hash: -1800442929
                        HadoopFsRelation hash: 875700892
                            InMemoryFileIndex hash: 765176865
                            StructType hash: 1
                            StructType hash: -1088120637
                            None hash: 2433880
                            GpuReadParquetFileFormat hash: 1726608894
                            CaseInsensitiveMap hash: 360779601
                        :: hash: -753333432
                            AttributeReference hash: -403150997
                            :: hash: -1613714654
                        StructType hash: -1088120637
                        Nil hash: 473519988
                        None hash: 2433880
                        None hash: 2433880
                        :: hash: -1179116297
                            EqualTo hash: -2127338661
                            :: hash: -832803998
                        None hash: 2433880
                        Boolean hash: 1237
                        Boolean hash: 1237
                        None hash: 2433880
                        None hash: 2433880
23/12/26 13:14:47 WARN GpuTransitionOverrides: ==>REUSED_EX_DEBUG: try fix up children of an exchange
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: Start to look at reused exchange under None
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: reuse exchange enabled ?= true with input plan GpuColumnarExchange, current Map: 
    1651290344 -> exchange(id: 899, canonicalized hash: 1651290344)
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: the cached exchange(id: 899, canonicalized hash: 1651290344) can be reused by exchange(id: 964, canonicalized hash: 1651290344)
Whole tree info:
    GpuShuffleExchangeExec hash: 1651290344
        GpuHashPartitioning hash: 506624161
            ArrayBuffer hash: 195585138
            Integer hash: 200
        ENSURE_REQUIREMENTS hash: -1256111375
        None hash: 2433880
        GpuHashAggregateExec hash: 992064433
            None hash: 2433880
            ArrayBuffer hash: -1343466678
            :: hash: 1577311079
                GpuAggregateExpression hash: -65238598
                :: hash: -895177707
            :: hash: 1871809590
                AttributeReference hash: -1481402425
                :: hash: -2133478641
            ArrayBuffer hash: 1119666541
            Long hash: 1073741824
            Boolean hash: 1231
            Double hash: -1806074301
            Boolean hash: 1237
            Boolean hash: 1237
            GpuProjectExec hash: 636852867
                :: hash: 411458217
                    AttributeReference hash: -403150997
                    :: hash: 1995159257
                GpuFilterExec hash: -451143750
                    GpuAnd hash: -1213905005
                        GpuEqualTo hash: -1874827664
                        GpuIsNotNull hash: 1232619969
                    GpuFileSourceScanExec hash: -1800442929
                        HadoopFsRelation hash: 875700892
                            InMemoryFileIndex hash: 765176865
                            StructType hash: 1
                            StructType hash: -1088120637
                            None hash: 2433880
                            GpuReadParquetFileFormat hash: 1726608894
                            CaseInsensitiveMap hash: 360779601
                        :: hash: -753333432
                            AttributeReference hash: -403150997
                            :: hash: -1613714654
                        StructType hash: -1088120637
                        Nil hash: 473519988
                        None hash: 2433880
                        None hash: 2433880
                        :: hash: -1179116297
                            EqualTo hash: -2127338661
                            :: hash: -832803998
                        None hash: 2433880
                        Boolean hash: 1237
                        Boolean hash: 1237
                        None hash: 2433880
                        None hash: 2433880
23/12/26 13:14:47 WARN GpuTransitionOverrides: ==>REUSED_EX_DEBUG: try fix up children of an exchange
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: Start to look at reused exchange under None
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: reuse exchange enabled ?= true with input plan GpuColumnarExchange, current Map: 
    1651290344 -> exchange(id: 899, canonicalized hash: 1651290344)
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: the cached exchange(id: 899, canonicalized hash: 1651290344) can be reused by exchange(id: 1031, canonicalized hash: 1651290344)
Whole tree info:
    GpuShuffleExchangeExec hash: 1651290344
        GpuHashPartitioning hash: 506624161
            ArrayBuffer hash: 195585138
            Integer hash: 200
        ENSURE_REQUIREMENTS hash: -1256111375
        None hash: 2433880
        GpuHashAggregateExec hash: 992064433
            None hash: 2433880
            ArrayBuffer hash: -1343466678
            :: hash: 1577311079
                GpuAggregateExpression hash: -65238598
                :: hash: -895177707
            :: hash: 1871809590
                AttributeReference hash: -1481402425
                :: hash: -2133478641
            ArrayBuffer hash: 1119666541
            Long hash: 1073741824
            Boolean hash: 1231
            Double hash: -1806074301
            Boolean hash: 1237
            Boolean hash: 1237
            GpuProjectExec hash: 636852867
                :: hash: 411458217
                    AttributeReference hash: -403150997
                    :: hash: 1995159257
                GpuFilterExec hash: -451143750
                    GpuAnd hash: -1213905005
                        GpuEqualTo hash: -1874827664
                        GpuIsNotNull hash: 1232619969
                    GpuFileSourceScanExec hash: -1800442929
                        HadoopFsRelation hash: 875700892
                            InMemoryFileIndex hash: 765176865
                            StructType hash: 1
                            StructType hash: -1088120637
                            None hash: 2433880
                            GpuReadParquetFileFormat hash: 1726608894
                            CaseInsensitiveMap hash: 360779601
                        :: hash: -753333432
                            AttributeReference hash: -403150997
                            :: hash: -1613714654
                        StructType hash: -1088120637
                        Nil hash: 473519988
                        None hash: 2433880
                        None hash: 2433880
                        :: hash: -1179116297
                            EqualTo hash: -2127338661
                            :: hash: -832803998
                        None hash: 2433880
                        Boolean hash: 1237
                        Boolean hash: 1237
                        None hash: 2433880
                        None hash: 2433880
23/12/26 13:14:47 WARN GpuTransitionOverrides: ==>REUSED_EX_DEBUG: try fix up children of an exchange
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: Start to look at reused exchange under None
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: reuse exchange enabled ?= true with input plan GpuColumnarExchange, current Map: 
    1651290344 -> exchange(id: 899, canonicalized hash: 1651290344)
23/12/26 13:14:47 WARN GpuOverrides: ==>REUSED_EX_DEBUG: the cached exchange(id: 899, canonicalized hash: 1651290344) can be reused by exchange(id: 1098, canonicalized hash: 1651290344)
Whole tree info:
    GpuShuffleExchangeExec hash: 1651290344
        GpuHashPartitioning hash: 506624161
            ArrayBuffer hash: 195585138
            Integer hash: 200
        ENSURE_REQUIREMENTS hash: -1256111375
        None hash: 2433880
        GpuHashAggregateExec hash: 992064433
            None hash: 2433880
            ArrayBuffer hash: -1343466678
            :: hash: 1577311079
                GpuAggregateExpression hash: -65238598
                :: hash: -895177707
            :: hash: 1871809590
                AttributeReference hash: -1481402425
                :: hash: -2133478641
            ArrayBuffer hash: 1119666541
            Long hash: 1073741824
            Boolean hash: 1231
            Double hash: -1806074301
            Boolean hash: 1237
            Boolean hash: 1237
            GpuProjectExec hash: 636852867
                :: hash: 411458217
                    AttributeReference hash: -403150997
                    :: hash: 1995159257
                GpuFilterExec hash: -451143750
                    GpuAnd hash: -1213905005
                        GpuEqualTo hash: -1874827664
                        GpuIsNotNull hash: 1232619969
                    GpuFileSourceScanExec hash: -1800442929
                        HadoopFsRelation hash: 875700892
                            InMemoryFileIndex hash: 765176865
                            StructType hash: 1
                            StructType hash: -1088120637
                            None hash: 2433880
                            GpuReadParquetFileFormat hash: 1726608894
                            CaseInsensitiveMap hash: 360779601
                        :: hash: -753333432
                            AttributeReference hash: -403150997
                            :: hash: -1613714654
                        StructType hash: -1088120637
                        Nil hash: 473519988
                        None hash: 2433880
                        None hash: 2433880
                        :: hash: -1179116297
                            EqualTo hash: -2127338661
                            :: hash: -832803998
                        None hash: 2433880
                        Boolean hash: 1237
                        Boolean hash: 1237
                        None hash: 2433880
                        None hash: 2433880
23/12/26 13:14:47 WARN GpuTransitionOverrides: ==>REUSED_EX_DEBUG: try fix up children of an exchange
```