### PR TITLE
fix a reuse issue for exchanges

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -638,7 +638,7 @@ case class GpuFileSourceScanExec(
       output.map(QueryPlan.normalizeExpressions(_, output)),
       requiredSchema,
       QueryPlan.normalizePredicates(
-        filterUnusedDynamicPruningExpressions(partitionFilters), output),
+        filterUnusedDynamicPruningExpressions(partitionFilters), originalOutput),
       optionalBucketSet,
       optionalNumCoalescedBuckets,
       QueryPlan.normalizePredicates(dataFilters, output),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -633,6 +633,7 @@ case class GpuFileSourceScanExec(
   }
 
   override def doCanonicalize(): GpuFileSourceScanExec = {
+    logInfo("doCanonicalize with a reuse fix")
     GpuFileSourceScanExec(
       relation,
       output.map(QueryPlan.normalizeExpressions(_, output)),

--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -636,13 +636,13 @@ case class GpuFileSourceScanExec(
     logInfo("doCanonicalize with a reuse fix")
     GpuFileSourceScanExec(
       relation,
-      output.map(QueryPlan.normalizeExpressions(_, output)),
+      originalOutput.map(QueryPlan.normalizeExpressions(_, originalOutput)),
       requiredSchema,
       QueryPlan.normalizePredicates(
         filterUnusedDynamicPruningExpressions(partitionFilters), originalOutput),
       optionalBucketSet,
       optionalNumCoalescedBuckets,
-      QueryPlan.normalizePredicates(dataFilters, output),
+      QueryPlan.normalizePredicates(dataFilters, originalOutput),
       None,
       queryUsesInputFile,
       alluxioPathsMap = alluxioPathsMap)(rapidsConf)


### PR DESCRIPTION
The original output should be used when creating a canonicalized GPU file scan, because one rule in the Plugin may prune the partition columns that are not used according to the first downstream `ProjectExec` for some patterns, leading to some useless columns not exist in the `output`.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
