### PR TITLE
Improve GpuExpand by pre-projecting some columns

### DIFF
--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2024, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 package com.nvidia.spark.rapids
+
+import scala.collection.mutable
+import scala.util.Random
 
 import ai.rapids.cudf.NvtxColor
 import com.nvidia.spark.rapids.Arm.withResource
@@ -88,7 +91,23 @@ case class GpuExpandExec(
     AttributeSet(projections.flatten.flatMap(_.references))
 
   override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] = {
-    val boundProjections = projections.map { pl =>
+    val notAllLeaf = preprojectionList.exists(_.children.nonEmpty)
+    val (finalProjections, preprojectIter) = if (useTieredProject && notAllLeaf) {
+      // Got some complicated expressions and tiered projection is enabled.
+      // Then try to do the pre-projection first.
+      val boundPreprojections = GpuBindReferences.bindGpuReferencesTiered(
+        preprojectionList, child.output, useTieredProject)
+      val preprojectIterFunc: Iterator[ColumnarBatch] => Iterator[ColumnarBatch] = iter =>
+        iter.map(cb =>
+          boundPreprojections.projectAndCloseWithRetrySingleBatch(
+            SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
+        )
+      (updatedProjections, preprojectIterFunc)
+    } else {
+      (projections, identity[Iterator[ColumnarBatch]] _)
+    }
+
+    val boundProjections = finalProjections.map { pl =>
       GpuBindReferences.bindGpuReferencesTiered(pl, child.output, useTieredProject)
     }
 
@@ -96,7 +115,7 @@ case class GpuExpandExec(
     val metricsMap = allMetrics
 
     child.executeColumnar().mapPartitions { it =>
-      new GpuExpandIterator(boundProjections, metricsMap, it)
+      new GpuExpandIterator(boundProjections, metricsMap, preprojectIter(it))
     }
   }
 
@@ -104,6 +123,45 @@ case class GpuExpandExec(
     throw new IllegalStateException("ROW BASED PROCESSING IS NOT SUPPORTED")
   }
 
+  /**
+   * Get the expressions that need to be pre-projected, along with the updated
+   * projections for expanding.
+   *
+   * Some Spark platforms will put non-leaf expressions in Expand projections,
+   * then it can not leverage the GPU tiered projection across the projection lists.
+   * So here tries to factor out these expressions and evaluate them before
+   * expanding to avoid duplicate evaluation for semantic-equal (sub) expressions.
+   */
+  private[this] lazy val (preprojectionList, updatedProjections) = {
+    val projectListBuffer = mutable.Set[NamedExpression]()
+    val newProjections = projections.map { proList =>
+      proList.map {
+        case attr: AttributeReference if child.outputSet.contains(attr) =>
+          // A ref to child output, add it to pre-projection for passthrough.
+          projectListBuffer += attr
+          attr
+        case leaf if leaf.children.isEmpty =>
+          // A leaf expression is simple enough, not necessary for pre-projection.
+          // e.g. GpuLiteral, and two internal columns (grouping id and grouping
+          // position) specific to Expand.
+          leaf
+        case notLeafNamed: NamedExpression =>
+          logWarning(s"==>Got a named non-leaf expression: $notLeafNamed for preprojection")
+          // A named expression, e.g. GpuAlias. Add it for pre-projection.
+          projectListBuffer += notLeafNamed
+          // Replace with its reference
+          notLeafNamed.toAttribute
+        case notLeaf =>
+          // Wrap by a GpuAlias
+          logWarning(s"==>Got a non-leaf expression: $notLeaf for preprojection")
+          val alias = GpuAlias(notLeaf, s"_preproject-c${Random.nextInt}")()
+          projectListBuffer += alias
+          // Replace with the reference of the new GpuAlias.
+          alias.toAttribute
+      }
+    }
+    (projectListBuffer.toList, newProjections)
+  }
 }
 
 class GpuExpandIterator(

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
@@ -92,7 +92,7 @@ case class GpuExpandExec(
 
   override protected def internalDoExecuteColumnar(): RDD[ColumnarBatch] = {
     val notAllLeaf = preprojectionList.exists(_.children.nonEmpty)
-    val (finalProjections, preprojectIter) = if (useTieredProject && notAllLeaf) {
+    val (boundProjections, preprojectIter) = if (useTieredProject && notAllLeaf) {
       // Got some complicated expressions and tiered projection is enabled.
       // Then try to do the pre-projection first.
       val boundPreprojections = GpuBindReferences.bindGpuReferencesTiered(
@@ -102,13 +102,16 @@ case class GpuExpandExec(
           boundPreprojections.projectAndCloseWithRetrySingleBatch(
             SpillableColumnarBatch(cb, SpillPriorities.ACTIVE_ON_DECK_PRIORITY))
         )
-      (updatedProjections, preprojectIterFunc)
+      val preprojectAttrs = preprojectionList.map(_.toAttribute)
+      val boundLists = updatedProjections.map { pl =>
+        GpuBindReferences.bindGpuReferencesTiered(pl, preprojectAttrs, useTieredProject)
+      }
+      (boundLists, preprojectIterFunc)
     } else {
-      (projections, identity[Iterator[ColumnarBatch]] _)
-    }
-
-    val boundProjections = finalProjections.map { pl =>
-      GpuBindReferences.bindGpuReferencesTiered(pl, child.output, useTieredProject)
+      val boundLists = projections.map { pl =>
+        GpuBindReferences.bindGpuReferencesTiered(pl, child.output, useTieredProject)
+      }
+      (boundLists, identity[Iterator[ColumnarBatch]] _)
     }
 
     // cache in a local to avoid serializing the plan

--- a/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
+++ b/sql-plugin/src/main/scala/com/nvidia/spark/rapids/GpuExpandExec.scala
@@ -127,9 +127,10 @@ case class GpuExpandExec(
    * Get the expressions that need to be pre-projected, along with the updated
    * projections for expanding.
    *
-   * Some Spark platforms will put non-leaf expressions in Expand projections,
-   * then it can not leverage the GPU tiered projection across the projection lists.
-   * So here tries to factor out these expressions and evaluate them before
+   * Some rules (e.g. RewriteDistinctAggregates) in Spark will put non-leaf expressions
+   * in Expand projections, then it can not leverage the GPU tiered projection across
+   * the projection lists.
+   * So here tries to factor out these expressions for later evaluations before
    * expanding to avoid duplicate evaluation for semantic-equal (sub) expressions.
    */
   private[this] lazy val (preprojectionList, updatedProjections) = {


### PR DESCRIPTION
Some rules in Spark will put non-leaf expressions into Expand projections,
then it can not leverage the GPU tiered projection across the projection lists.
 
So this PR tries to factor out these expressions and evaluate them before
expanding to avoid duplicate evaluation for semantic-equal (sub) expressions.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
