### PR TITLE
Revert "Fix the canonicalizing for GPU file scan (#10137)"

### DIFF
--- a/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
+++ b/sql-plugin/src/main/scala/org/apache/spark/sql/rapids/GpuFileSourceScanExec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -635,13 +635,13 @@ case class GpuFileSourceScanExec(
   override def doCanonicalize(): GpuFileSourceScanExec = {
     GpuFileSourceScanExec(
       relation,
-      originalOutput.map(QueryPlan.normalizeExpressions(_, originalOutput)),
+      output.map(QueryPlan.normalizeExpressions(_, output)),
       requiredSchema,
       QueryPlan.normalizePredicates(
-        filterUnusedDynamicPruningExpressions(partitionFilters), originalOutput),
+        filterUnusedDynamicPruningExpressions(partitionFilters), output),
       optionalBucketSet,
       optionalNumCoalescedBuckets,
-      QueryPlan.normalizePredicates(dataFilters, originalOutput),
+      QueryPlan.normalizePredicates(dataFilters, output),
       None,
       queryUsesInputFile,
       alluxioPathsMap = alluxioPathsMap)(rapidsConf)

--- a/tests/src/test/scala/com/nvidia/spark/rapids/GpuFileScanPrunePartitionSuite.scala
+++ b/tests/src/test/scala/com/nvidia/spark/rapids/GpuFileScanPrunePartitionSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,29 +83,6 @@ class GpuFileScanPrunePartitionSuite extends SparkQueryCompareTestSuite {
         }
         testGpuFileScanOutput(_.select("a", "c").filter("a != 1"), conf, "b")
         testGpuFileScanOutput(_.select("a").filter("a != 1"), conf, "b", "c")
-    }
-  }
-
-  test("Canonicalized GpuFileSourceScans with partition columns pruned should be equal") {
-    withTempPath { file =>
-      // Generate partitioned files.
-      withCpuSparkSession(spark => {
-        import spark.implicits._
-        Seq((1, 11, "s1"), (2, 22, "s2"), (3, 33, "s3"), (4, 44, "s4"), (5, 55, "s5"))
-          .toDF("a", "b", "c").write.partitionBy("b", "c").parquet(file.getCanonicalPath)
-      })
-
-      def getDF: DataFrame = withGpuSparkSession(spark =>
-        spark.read.parquet(file.toString).where("b == 33").select("a", "c"),
-        new SparkConf().set("spark.sql.sources.useV1SourceList", "parquet")
-      )
-
-      val plans = getDF.unionAll(getDF).queryExecution.executedPlan.collect {
-        case gfss: GpuFileSourceScanExec if gfss.requiredPartitionSchema.nonEmpty => gfss
-      }
-      assert(plans.length == 2, "Expect 2 GPU file scans")
-      assert(plans.head.canonicalized == plans.last.canonicalized,
-          "Canonicalized GPU file scans should be equal")
     }
   }
 }


### PR DESCRIPTION
This reverts commit ace4870f6593125393f1c8e14f937028acaf4372.

<!--

Thank you for contributing to RAPIDS Accelerator for Apache Spark!

Here are some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that you have written units tests for the changes made/features
   added.

3. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

4. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]`.

5. If your pull request is ready to be reviewed without requiring additional
   work on top of it, then remove the `[WIP]` label (if present).

6. Once all work has been done and review has taken place please do not add
   features or make changes out of the scope of those requested by the reviewer
   (doing this just add delays as already reviewed code ends up having to be
   re-reviewed/it is hard to tell what is new etc!). Further, please avoid
   rebasing your branch during the review process, as this causes the context
   of any comments made by reviewers to be lost. If conflicts occur during
   review then they should be resolved by merging into the branch used for
   making the pull request.

Many thanks in advance for your cooperation!

-->
